### PR TITLE
Update DBCStores.cpp - fix for wrong XP calculation in Worgen + Goblin start zones

### DIFF
--- a/src/game/DBCStores.cpp
+++ b/src/game/DBCStores.cpp
@@ -983,6 +983,12 @@ ContentLevels GetContentLevelsForMap(uint32 mapid)
     MapEntry const* mapEntry = sMapStore.LookupEntry(mapid);
     if (!mapEntry)
         return CONTENT_1_60;
+        
+	if (mapid = 654) //654 = Worgen Starter area. 
+		return CONTENT_1_60;
+
+	if (mapid = 648) //648 = Goblin Starter area. 
+		return CONTENT_1_60;
 
     switch (mapEntry->Expansion())
     {


### PR DESCRIPTION
This will fix problem with Excessive XP being granted in the starter zones for Worgen and Goblin races.